### PR TITLE
bump chart version to be able to use the chart

### DIFF
--- a/standard-service/Chart.yaml
+++ b/standard-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: coremaker-standard-service
-version: 0.1.7
+version: 0.1.9
 description: This is the coremaker common helm chart used to deploy our services


### PR DESCRIPTION
Just bumping chart version and will mark 0.1.8 as not working.