### PR TITLE
make istio selectors configurable

### DIFF
--- a/standard-service/Chart.yaml
+++ b/standard-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: coremaker-standard-service
-version: 0.2.2
+version: 0.2.3
 description: This is the coremaker common helm chart used to deploy our services

--- a/standard-service/templates/deployment.yaml
+++ b/standard-service/templates/deployment.yaml
@@ -10,8 +10,10 @@ spec:
   selector:
     matchLabels:
       app_name: {{ template "coremaker-common-chart.fullname" . }}
+{{- if .Values.istio.selectors }}
       app: {{ template "coremaker-common-chart.fullname" . }}
       version: v1
+{{- end }}
   template:
     metadata:
       labels:

--- a/standard-service/templates/service.yaml
+++ b/standard-service/templates/service.yaml
@@ -23,5 +23,7 @@ spec:
       targetPort: {{ .Values.container.ports.port }}
   selector:
     app_name: {{ template "coremaker-common-chart.fullname" . }}
+{{- if .Values.istio.selectors }}
     app: {{ template "coremaker-common-chart.fullname" . }}
     version: v1
+{{- end }} 

--- a/standard-service/values.yaml
+++ b/standard-service/values.yaml
@@ -186,3 +186,6 @@ fluxv2:
     interval: 5m
     suspend: false
     gcrSecretName: fluxv2-gcr-credentials
+
+istio:
+  selectors: false


### PR DESCRIPTION
Fixing an issue where upgrades from versions <0.2.0 were not possible because of the istio selectors we added on the deployment which are immutable.

This only adds the option to disable the additional selectors.